### PR TITLE
V1.8

### DIFF
--- a/Readme.txt
+++ b/Readme.txt
@@ -1,0 +1,34 @@
+v1.7
+
+cf_weap_main:
+- N/A
+
+cf_weap_flares
+- Massively increases the brightness and intensity of the vanilla flares.
+
+cf_weap_nia_ak:
+- Set zoom distances on all weapons to vanilla values.
+
+cf_weap_nia_m14
+- Added compatibility for RHS scopes to the M14 DMR (RIS).
+- Added compatibility for RHS 7.62 magazines to all M14s.
+
+cf_weap_po:
+- Set AI firing modes & dispersion to levels that fit Charlie Foxtrot's gameplay style.
+
+cf_weap_rhs_afrf:
+- Set AI firing modes & dispersion to levels that fit Charlie Foxtrot's gameplay style.
+- Set zoom distances on all weapons to vanilla values.
+
+cf_weap_rhs_gref:
+- Set AI firing modes & dispersion to levels that fit Charlie Foxtrot's gameplay style.
+- Set zoom distances on all weapons to vanilla values.
+- Fixes a bug where JSRS causes the AI to fire some pistols at extreme ranges.
+
+cf_weap_usf:
+- Set AI firing modes & dispersion to levels that fit Charlie Foxtrot's gameplay style.
+- Set zoom distances on all weapons to vanilla values.
+- Fixes a bug where JSRS causes the AI to fire some pistols at extreme ranges.
+
+-cf_weap_vanilla:
+- Set AI firing modes & dispersion to levels that fit Charlie Foxtrot's gameplay style (Syndikat faction only).

--- a/Readme.txt
+++ b/Readme.txt
@@ -1,4 +1,4 @@
-v1.7
+v1.8
 
 cf_weap_main:
 - N/A

--- a/cf_weap_flares/$PBOPREFIX$
+++ b/cf_weap_flares/$PBOPREFIX$
@@ -1,0 +1,1 @@
+cf_weap_flares

--- a/cf_weap_flares/config.cpp
+++ b/cf_weap_flares/config.cpp
@@ -28,35 +28,35 @@ class CfgAmmo {
 	
 	class CF_F_40mm_White: F_40mm_White {
 		access = 1;
-		timeToLive = 60;
+		timeToLive = 50;
         brightness = 300;
         intensity  = 2000000;
 	};
 	
 	class CF_F_40mm_Green: F_40mm_Green {
 		access = 1;
-		timeToLive = 60;
+		timeToLive = 50;
         brightness = 300;
         intensity  = 2000000;
 	};
 	
 	class CF_F_40mm_Yellow: F_40mm_Yellow {
 		access = 1;
-		timeToLive = 60;
+		timeToLive = 50;
         brightness = 300;
         intensity  = 2000000;
 	};
 	
 	class CF_F_40mm_Red: F_40mm_Red {
 		access = 1;
-		timeToLive = 60;
+		timeToLive = 50;
         brightness = 300;
         intensity  = 2000000;
 	};
 	
 	class CF_F_40mm_Cir: F_40mm_Cir {
 		access = 1;
-		timeToLive = 60;
+		timeToLive = 50;
         brightness = 300;
         intensity  = 2000000;
 	};
@@ -69,35 +69,35 @@ class CfgAmmo {
 	
 	
 	class CF_F_20mm_White: F_20mm_White {
-		timeToLive = 60;
+		timeToLive = 50;
         brightness = 300;
         intensity  = 1800000;
 	};
 	
 	class CF_F_20mm_Green: F_20mm_Green {
 		access = 1;
-		timeToLive = 60;
+		timeToLive = 50;
         brightness = 300;
         intensity  = 1800000;
 	};
 	
 	class CF_F_20mm_Yellow: F_20mm_Yellow {
 		access = 1;
-		timeToLive = 60;
+		timeToLive = 50;
         brightness = 300;
         intensity  = 1800000;
 	};
 	
 	class CF_F_20mm_Red: F_20mm_Red {
 		access = 1;
-		timeToLive = 60;
+		timeToLive = 50;
         brightness = 300;
         intensity  = 1800000;
 	};
 	
 	class CF_F_20mm_Cir: F_20mm_Cir {
 		access = 1;
-		timeToLive = 60;
+		timeToLive = 50;
         brightness = 300;
         intensity  = 1800000;
 	};

--- a/cf_weap_flares/config.cpp
+++ b/cf_weap_flares/config.cpp
@@ -1,0 +1,145 @@
+class CfgPatches
+{
+	class CF_Weapons_Flares
+	{
+		// Use meta information from specified addon. Used to avoid repeated declarations.
+		addonRootClass = "CF_Weapons";
+ 
+		requiredVersion = 1.62;
+		requiredAddons[] = {"A3_Weapons_F"};
+		units[] = {};
+		weapons[] = {};
+	};
+};
+
+class Default; // External class reference
+
+class CfgAmmo {
+	
+	class GrenadeCore: Default {};
+	class FlareCore: GrenadeCore {};
+	class FlareBase: FlareCore {};
+	
+	class F_40mm_White: FlareBase {};
+	class F_40mm_Green: F_40mm_White {};
+	class F_40mm_Red: F_40mm_White {};
+	class F_40mm_Yellow: F_40mm_White {};
+	class F_40mm_Cir: F_40mm_White {};
+	
+	class CF_F_40mm_White: F_40mm_White {
+		access = 1;
+		timeToLive = 60;
+        brightness = 300;
+        intensity  = 2000000;
+	};
+	
+	class CF_F_40mm_Green: F_40mm_Green {
+		access = 1;
+		timeToLive = 60;
+        brightness = 300;
+        intensity  = 2000000;
+	};
+	
+	class CF_F_40mm_Yellow: F_40mm_Yellow {
+		access = 1;
+		timeToLive = 60;
+        brightness = 300;
+        intensity  = 2000000;
+	};
+	
+	class CF_F_40mm_Red: F_40mm_Red {
+		access = 1;
+		timeToLive = 60;
+        brightness = 300;
+        intensity  = 2000000;
+	};
+	
+	class CF_F_40mm_Cir: F_40mm_Cir {
+		access = 1;
+		timeToLive = 60;
+        brightness = 300;
+        intensity  = 2000000;
+	};
+	
+    class F_20mm_White: FlareBase {};
+	class F_20mm_Green: F_20mm_White {};
+	class F_20mm_Red: F_20mm_White {};
+	class F_20mm_Yellow: F_20mm_White {};
+	class F_20mm_Cir: F_20mm_White {};
+	
+	
+	class CF_F_20mm_White: F_20mm_White {
+		timeToLive = 60;
+        brightness = 300;
+        intensity  = 1800000;
+	};
+	
+	class CF_F_20mm_Green: F_20mm_Green {
+		access = 1;
+		timeToLive = 60;
+        brightness = 300;
+        intensity  = 1800000;
+	};
+	
+	class CF_F_20mm_Yellow: F_20mm_Yellow {
+		access = 1;
+		timeToLive = 60;
+        brightness = 300;
+        intensity  = 1800000;
+	};
+	
+	class CF_F_20mm_Red: F_20mm_Red {
+		access = 1;
+		timeToLive = 60;
+        brightness = 300;
+        intensity  = 1800000;
+	};
+	
+	class CF_F_20mm_Cir: F_20mm_Cir {
+		access = 1;
+		timeToLive = 60;
+        brightness = 300;
+        intensity  = 1800000;
+	};
+};
+
+class CfgMagazines {
+	
+	class CA_Magazine: Default {};
+	
+	class UGL_FlareWhite_F: CA_Magazine {
+		ammo = "CF_F_40mm_White";
+	};
+	
+	class UGL_FlareGreen_F: UGL_FlareWhite_F {
+		ammo = "CF_F_40mm_Green";
+	};
+	
+	class UGL_FlareYellow_F: UGL_FlareWhite_F {
+		ammo = "CF_F_40mm_Yellow";
+	};
+	
+	class UGL_FlareRed_F: UGL_FlareWhite_F {
+		ammo = "CF_F_40mm_Red";
+	};
+	
+	class UGL_FlareCIR_F: UGL_FlareWhite_F {
+		ammo = "CF_F_40mm_CIR";
+	};
+	
+	class FlareWhite_F: CA_Magazine {
+		ammo = "CF_F_20mm_White";
+	};
+	
+	class FlareGreen_F: CA_Magazine {
+		ammo = "CF_F_20mm_Green";
+	};
+	
+	class FlareRed_F: CA_Magazine {
+		ammo = "CF_F_20mm_Red";
+	};
+	
+	class FlareYellow_F: CA_Magazine {
+		ammo = "CF_F_20mm_Yellow";
+	};
+};


### PR DESCRIPTION
Brightness, intensity and timeToLive changes by creating new classes (CF_*original flare classname*) and changing the vanilla flare magazine contents, because the original flare ammo's intensity couldn't be changed for unknown reasons (tried setting access to 1).

RHS flares are probably not affected.